### PR TITLE
Serialize regexp as strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,17 @@ function collectKeys (obj) {
  * @returns {String} stringified JSON object.
  */
 function serialize (obj) {
-  return JSON.stringify(obj, collectKeys(obj))
+  function serializeUnsupportedObjects (key, value) {
+    if (value instanceof RegExp) {
+      return String(value)
+    }
+
+    return value
+  }
+
+  const serialized = JSON.parse(JSON.stringify(obj, serializeUnsupportedObjects))
+
+  return JSON.stringify(serialized, collectKeys(obj))
 }
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -58,4 +58,9 @@ describe('JSum', function () {
     expect(jsum.serialize({ x: 3, a: { z: { l: 4, k: 3, a: 1, b: 2 }, c: 1 }, k: [{ l: 2, b: 1, z: 3 }, 4, 5] }))
       .to.equal('{"a":{"c":1,"z":{"a":1,"b":2,"k":3,"l":4}},"k":[{"b":1,"l":2,"z":3},4,5],"x":3}')
   })
+
+  it('should stringify regexes', function () {
+    expect(jsum.serialize({ a: /[a-zA-Z]/ }))
+      .to.equal('{"a":"/[a-zA-Z]/"}')
+  })
 })


### PR DESCRIPTION
When regexp is stringified it's being returned as `{}`, which computes the digest of two different objects as the same if the only difference is in the regexp part. Instead, we could cast the regexp to a string.

@yan-foto I'm not sure if that's the desired way for the project to proceed? Serializing JSON-unsupported objects might be tricky and various people might want to customize the behavior, please let me know what you think.

Fixes #10
Fixes #9 (as a side effect, because it `JSON.stringify(JSON.parse)` the incoming object)